### PR TITLE
Update copyright year to 2025 and revise credits links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ubeyde Emir Özdemir
+Copyright (c) 2025 Ubeyde Emir Özdemir
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -589,7 +589,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects.html
+++ b/projects.html
@@ -691,7 +691,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -741,7 +741,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/countrypedia.html
+++ b/projects/countrypedia.html
@@ -221,7 +221,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -275,7 +275,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/cremablog.html
+++ b/projects/cremablog.html
@@ -145,7 +145,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -199,7 +199,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/crematodoreact.html
+++ b/projects/crematodoreact.html
@@ -131,7 +131,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -185,7 +185,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/crematodovue.html
+++ b/projects/crematodovue.html
@@ -129,7 +129,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -183,7 +183,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/pokedexbot.html
+++ b/projects/pokedexbot.html
@@ -197,7 +197,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -251,7 +251,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>

--- a/projects/turkiyeapi.html
+++ b/projects/turkiyeapi.html
@@ -207,7 +207,7 @@
         </div>
       </section>
       <section class="footer">
-        <small class="footer__copyright">&copy; 2024 Ubeyde Emir Özdemir</small>
+        <small class="footer__copyright">&copy; 2025 Ubeyde Emir Özdemir</small>
         <div class="footer__social">
           <a
             class="footer__social-link"
@@ -261,7 +261,7 @@
           <a
             class="footer__text-link"
             target="_blank"
-            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#credits"
+            href="https://github.com/ubeydeozdmr/ubeydeozdmr.github.io/blob/main/README.md#-credits"
             >Credits</a
           >
         </div>


### PR DESCRIPTION
Update the copyright year in the LICENSE file and across project pages to reflect 2025. Adjust links to the credits section for consistency.